### PR TITLE
Update image pull policy for minikube to always, to get latest docker

### DIFF
--- a/k8s/charts/minikube/values.yaml
+++ b/k8s/charts/minikube/values.yaml
@@ -12,7 +12,7 @@ proxy:
   image:
     repository: rawsashimi/sushi-proxy
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
   ## Number of replicas to deploy
   replicaCount: 1
@@ -33,7 +33,7 @@ manager:
   image:
     repository: rawsashimi/sushi-manager
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   
   ## Number of replicas to deploy
   replicaCount: 1


### PR DESCRIPTION
Update image pull policy for minikube to always, to get latest docker